### PR TITLE
[#12] [feat] 대기중 상품 진행중으로 바꾸는 스케줄러 구현

### DIFF
--- a/src/main/java/f4/service/ProductServiceAPI.java
+++ b/src/main/java/f4/service/ProductServiceAPI.java
@@ -2,17 +2,15 @@ package f4.service;
 
 import f4.dto.ProductDto;
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 
 import java.util.List;
 
 @FeignClient(name = "PRODUCT-SERVICE")
 public interface ProductServiceAPI {
-
-  @GetMapping("")
-  List<ProductDto> getProductsToBeEnded();
+  @PutMapping("")
+  List<ProductDto> auctionStatusUpdateToEnd();
 
   @PutMapping("")
-  ProductDto auctionStatusUpdate(long productId);
+  void auctionStatusUpdateToProgress();
 }


### PR DESCRIPTION
기존에 user-service와 product-service에서 두 번 호출해야했던 로직을 product-service에서 한번에 처리될 수 있게 로직을 변경함.
따라서, API 호출 메소드명도 변경됨.

경매 종료로 변경은 자정
경매 시작은 오후 2시

* log추가